### PR TITLE
Agrego listado de traducciones de las imágenes

### DIFF
--- a/pics/PICS_TRANSLATION.md
+++ b/pics/PICS_TRANSLATION.md
@@ -1,0 +1,270 @@
+# Traducción de imágenes
+
+##  Polices
+[Patrick Hand](https://fonts.google.com/specimen/Patrick+Hand) (PH)
+[Open Sans](https://fonts.google.com/specimen/Open+Sans) (OS)
+
+## Traductions
+
+### exponential.png
+#### Original (English) 
+
+In just 10 doublings...
+
+#### Traduction (Español) 
+
+En apenas 10 duplicaciones...
+
+### masks.png
+#### Original (English) 
+
+Droplets get smaller as they fly away, due to evaporation.
+
+Masks are better at blocking large droplets, worse at small ones.
+
+That's why masks aren't effective at preventing *you* from getting sick...
+
+But they are effective at preventing you from getting *others* sick!
+
+#### Traduction (français) 
+
+Las gotas se vuelven más pequeñas a medida que se alejan, debido a la evaporación.
+
+Las mascarillas bloquean mejor las gotas grandes, y menos las pequeñas.
+
+Por eso es que las mascarillas no sirven para evitar que *vos* te enfermes...
+
+¡Pero sirven para que evites contagiar a *otras* personas!
+
+### mitigation_vs_suppression.png
+#### Original (English)
+
+Mitigation
+
+Suppression
+
+#### Traduction (Español) 
+
+Mitigación
+
+Supresión
+
+### plan.png
+#### Original (English) 
+
+The goal: R < 1.
+Starting with a...
+
+LOCKDOWN
+So we get a fresh start & buy time to switch to...
+
+TEST, TRACE, ISOLATE
+If not enough to get R<1, supplement with **Mask For All** and/or a "circuit breaker" lockdown, until we can...
+
+VACCINATE
+If immunity doesn't last, do regular vaccinations. If no vaccine, change behavioral norms until we can treat of cure it!
+
+#### Traduction (Español) 
+
+El objetivo: R < 1.
+Comenzando con un...
+
+CONFINAMIENTO
+Así arrancamos despacio y compramos tiempo para cambiar a...
+
+PRUEBAS, RASTREO, AISLAMIENTO
+Si no alcanzan para R<1, suplementar con **Mascarillas para todos** y/o un "cortocircuito", hasta que podamos...
+
+VACUNAR
+Si la inmunidad no dura, vacunar regularmente. Si no conseguimos vacuna, cambiar las normas de comportamiento hasta que podamos tratarlo o curarlo!
+
+
+### r2.png
+#### Original (English) 
+
+epidemic
+
+endemic
+
+contained!
+
+#### Traduction (Español) 
+
+epidemia
+
+endémico
+
+contenido!
+
+### r3.png
+#### Original (English) 
+
+BAD
+
+GOOD
+
+#### Traduction (Español) 
+
+MAL
+
+BIEN
+
+### r4.png
+#### Original (English) 
+
+if R_0 is
+
+(1.0 ... 4.0)
+
+then you need to stop more than
+
+(0%, ..., 75%)
+
+of transmission to get R<1, and stop the spread!
+
+#### Traduction (Español) 
+
+si R_0 es
+
+(1.0 ... 4.0)
+
+entonces necesitas frenar más del
+
+(0%, ..., 75%)
+
+de transmisiones para conseguir R<1, y frenar el contagio!
+
+
+### seir.png
+#### Original (English) 
+
+Slower when fewer
+faster when more
+
+Susceptible
+Exposed
+Infectious
+Recovered
+
+transmission
+incubation
+recovery
+
+#### Traduction (Spanish) 
+
+más lento cuantos menos
+más rápido cuantos más
+
+Suceptible
+Expuesto
+Infeccioso
+Recuperado
+
+contagio
+incubación
+recuperación
+
+### seirs.png
+#### Original (English) 
+
+Slower when fewer
+faster when more
+
+Susceptible
+Exposed
+Infectious
+Recovered
+
+transmission
+incubation
+recovery
+
+waning
+
+#### Traduction (Spanish) 
+
+
+
+### sir.png
+#### Original (English) 
+
+Slower when fewer
+faster when more
+
+Susceptible
+Infectious
+Recovered
+
+transmission
+recovery
+
+#### Traduction (Español) 
+
+
+
+### spread.png
+#### Original (English) 
+
+1 to 2...
+
+2 to 4...
+
+4 to 8...
+
+#### Traduction (Español) 
+
+1 a 2...
+
+2 a 4...
+
+4 a 8...
+
+### susceptibles.png
+#### Original (English) 
+
+When population ~100% _, a _ can infect 100% of contact
+
+When population ~50% _, a _ can infect 50% of contact
+
+When population ~0% _, a _ can infect 0% of contact
+
+#### Traduction (Español) 
+
+
+
+### timeline1.png
+#### Original (English) 
+
+day 0
+exposed
+
+day 3
+infectious
+
+day 5
+infectious (& now feels symptoms)
+
+day 4
+infects someone else
+
+#### Traduction (Español) 
+
+
+
+### timeline2.png
+#### Original (English) 
+
+isolate symptomatic cases
+
+#### Traduction (Español) 
+
+
+
+### timeline3.png
+#### Original (English) 
+
+isolate symptomatic cases *and* quarantine contacts
+
+#### Traduction (Español) 
+
+aislar casos sintomáticos *y* poner contactos en cuarentena


### PR DESCRIPTION
Faltan algunas. La idea es poder dárselas a alguien que haga las imágenes nuevas, pero con la traducción ya resuelta.

En ncase/covid-19#15 sugirieron inspirarse en la plantilla que crearon en la traducción francesa (y eso hice): https://github.com/cyrilou242/covid-19/blob/master/pics/PICS_TRANSLATION.md